### PR TITLE
solved problem with response body with simple format

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject weareswat/request-utils "0.1.0"
+(defproject weareswat/request-utils "0.2.0"
   :description "Some utilities to do async http requests with aleph"
   :url "https://github.com/weareswat/request-utils"
   :license {:name         "MIT"

--- a/src/request_utils/core.clj
+++ b/src/request_utils/core.clj
@@ -1,4 +1,4 @@
-(ns ^{:added "0.1.0" :author "Marcos Lamúria"}
+(ns ^{:added "0.2.0" :author "Marcos Lamúria"}
   request-utils.core
   (:require [cheshire.core :as json]
             [clojure.string :as clj-str]
@@ -107,7 +107,7 @@
     (merge {:success (get-success response)
             :status (:status response)
             :requests (inc (:requests data))}
-           (json/parse-string (slurp (:body response)) true))
+            {:body (json/parse-string (slurp (:body response)) true)})
     (catch Exception ex
       {:exception ex})))
 


### PR DESCRIPTION
We were returning a properly formated response to the client by doing
this:

``` clojure
  (merge {:success (get-success response)
          :status (:status response)
          :requests (inc (:requests data))}
          (json/parse-string (slurp (:body response)) true))
```

The problem with this was when we got the most simple json on response
body, which on our case was values like `true` or `false`, so, we're
trying to execute a `merge` with a map and a string and because of this
we got an error. Now you're binding the response body to `:body` key
