### PR TITLE
Allow non json responses

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject weareswat/request-utils "0.2.0"
+(defproject weareswat/request-utils "0.3.0"
   :description "Some utilities to do async http requests with aleph"
   :url "https://github.com/weareswat/request-utils"
   :license {:name         "MIT"

--- a/test/request_utils/core_test.clj
+++ b/test/request_utils/core_test.clj
@@ -112,3 +112,8 @@
   (let [result (<!! (core/http-get {:host "http://app.clanhr.com/directory-api/"}))]
     (is (= 200
            (:status result)))))
+
+(deftest http-get-non-json-response
+  (let [result (<!! (core/http-get {:host "http://www.google.com"
+                                    :plain-body? true}))]
+    (is (= 200 (:status result)))))


### PR DESCRIPTION
By default this libs converts a response body to json. But there are scenarios
where we don't want that.

For example, we may want a request for an endpoint that returns HTML, XML or
simply plain text.

Added a `:plain-text? true` option that will bypass that conversion.
