### PR TITLE
Improve json handling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject weareswat/request-utils "0.4.0"
+(defproject weareswat/request-utils "0.4.1"
   :description "Some utilities to do async http requests with aleph"
   :url "https://github.com/weareswat/request-utils"
   :license {:name         "MIT"

--- a/test/request_utils/core_test.clj
+++ b/test/request_utils/core_test.clj
@@ -122,3 +122,10 @@
   (let [result (<!! (core/http-get {:host "http://www.google.com"
                                     :plain-body? true}))]
     (is (= 200 (:status result)))))
+
+(deftest invalid-json-proper-error
+  (let [result (<!! (core/http-get {:host "http://www.google.com"}))]
+    (is (result/failed? result))))
+
+(deftest sanitize-json-test
+  (is (= "\"Hello" (core/sanitize-json (str "\"Hello" (char 65279))))))


### PR DESCRIPTION
Start by properly catching a json exception and notify and also show the
body that generated the error.

This was needed because we were having an error with a hidden char
(65279) that we did not see but was there. We added something to clear
that.
