### PR TITLE
Don't retry on post/put

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject weareswat/request-utils "0.5.0"
+(defproject weareswat/request-utils "0.6.0"
   :description "Some utilities to do async http requests with aleph"
   :url "https://github.com/weareswat/request-utils"
   :license {:name         "MIT"

--- a/src/request_utils/core.clj
+++ b/src/request_utils/core.clj
@@ -53,6 +53,13 @@
   [http-ops data]
   (assoc http-ops :body (parse-body data)))
 
+(defn default-tries
+  "Gets the default tries to execute based on the method"
+  [method]
+  (if (= method :get)
+    3
+    1))
+
 (defn prepare-data
   "Prepares all the data to do the request. This function receives the HTTP
   method and the data to send as parameters.
@@ -87,7 +94,8 @@
                       (add-body (:body data)))]
     (assoc data :host (:host data)
                 :requests 0
-                :retries (- (or (:retries data) 3) 1)
+                :retries (dec (or (:retries data)
+                                  (default-tries method)))
                 :url (build-url (:host data) (:path data) (:query-params data))
                 :http-opts http-opts
                 :request-method method

--- a/test/request_utils/core_test.clj
+++ b/test/request_utils/core_test.clj
@@ -83,7 +83,7 @@
              (:host result))))
 
     (testing "retries"
-      (is (= 2
+      (is (= 0
              (:retries result))))
 
     (testing "url"
@@ -129,3 +129,8 @@
 
 (deftest sanitize-json-test
   (is (= "\"Hello" (core/sanitize-json (str "\"Hello" (char 65279))))))
+
+(deftest default-tries-test
+  (is (= 3 (core/default-tries :get)))
+  (is (= 1 (core/default-tries :post)))
+  (is (= 1 (core/default-tries :put))))


### PR DESCRIPTION
Posts and puts may have side effects so we need to be very careful when
retrying. Now by default we don't retry at all.